### PR TITLE
composer.json generates errors to composer install/update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "symfony-bundle",
     "license": "MIT",
     "require": {
-        "sensio/generator-bundle": "2.1.x-dev"
+        "sensio/generator-bundle": "2.1.*"
     },
     "minimum-stability": "dev",
     "authors": [


### PR DESCRIPTION
Hi!

Requiring:

```
"require": {
    "sensio/generator-bundle": "2.1.x-dev"
},
```

generates dependency error on Symfony 2.1.6. I'd had to clone locally, changes symfony's composer.json to point to this local repository after change the bundle's composer.json to:

```
"require": {
    "sensio/generator-bundle": "2.1.*"
},
```

and then it worked. 

My pull request do that thing.

Thanks for the bundle!

Rafael Goulart from Brazil
